### PR TITLE
Fix leaking global variable 'url'.

### DIFF
--- a/lib/embedly.js
+++ b/lib/embedly.js
@@ -58,6 +58,7 @@ var parse_host = function(host) {
   var port = 80
     , protocol = 'http'
     , match = host.match(/^(https?:\/\/)?([^\/:]+)(:\d+)?\/?$/)
+    , url
     ;
 
   if (!match) {


### PR DESCRIPTION
There was a leaking `url` variable before. Fixed.
