### PR TITLE
Timeout is defined in config object, but not set to request object

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ embedly.prototype.apiCall = function(endpoint, version, q, fn) {
     self.config.logger.debug('calling: ' + url + '?' + querystring.stringify(q));
     var req = request
       .get(url)
+      .timeout(self.config.timeout)
       .set('User-Agent', self.config.userAgent)
       .set('Accept', 'application/json');
     req.query(querystring.stringify(q));


### PR DESCRIPTION
Set the timeout config option, without it default value is used and it's higher than the Heroku's router request timeout value 30seconds.