### PR TITLE
upgrades version of superagent

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "test": "./test"
   },
   "dependencies": {
+    "hashish": "0.0.4",
     "lodash": "4.13.1",
-    "superagent": "1.8.3",
     "sprintf": "0.1.1",
-    "hashish": "0.0.4"
+    "superagent": "3.5.2"
   },
   "devDependencies": {
     "mocha": "1.8.2",


### PR DESCRIPTION
The current version of `embedly-node` contains some security vulnerabilities introduced via an older version of `superagent`. See [here](https://snyk.io/test/npm/embedly) for details. 

This PR addresses said vulnerabilities by updating the version of `superagent`. Although it contains a multiple major version upgrade, superagent is used in a minor capacity in this repo, and doesn't appear to affect use. 

Additionally, `dependencies` in `package.json` has been alphabetized via use of `npm install`. 