### PR TITLE
Use SuperAgent Request Timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ embedly.prototype.apiCall = function(endpoint, version, q, fn) {
     self.config.logger.debug('calling: ' + url + '?' + querystring.stringify(q));
     var req = request
       .get(url)
+      .timeout(self.config.timeout)
       .set('User-Agent', self.config.userAgent)
       .set('Accept', 'application/json');
     req.query(querystring.stringify(q));


### PR DESCRIPTION
Currently this package doesn't send the timeout value to superagent. This PR adds it so we can prevent waiting for long-running HTTP requests.